### PR TITLE
msm8937: arm64: remove vfe_secure dtsi entry

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8937-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8937-camera.dtsi
@@ -323,12 +323,6 @@
 			qcom,scratch-buf-support;
 		};
 
-		msm_cam_smmu_cb2: msm_cam_smmu_cb2 {
-			compatible = "qcom,qsmmu-cam-cb";
-			label = "vfe_secure";
-			qcom,secure-context;
-		};
-
 		msm_cam_smmu_cb3: msm_cam_smmu_cb3 {
 			compatible = "qcom,qsmmu-cam-cb";
 			iommus = <&apps_iommu 0x1c00>;


### PR DESCRIPTION
[    5.684876] /soc/qcom,cam_smmu/msm_cam_smmu_cb1: could not get #iommu-cells for /soc/qcom,iommu@1e00000
[    5.685406] CAM-SMMU cam_populate_smmu_context_banks:1586 Invalid pointer of ctx : vfe_secure rc = -517
[    5.685408] CAM-SMMU cam_smmu_probe:1636 Error: populating context banks
[    5.685415] msm_cam_smmu: probe of soc:qcom,cam_smmu:msm_cam_smmu_cb2 failed with error -12
[    5.685507] /soc/qcom,cam_smmu/msm_cam_smmu_cb3: could not get #iommu-cells for /soc/qcom,iommu@1e00000
[    5.685746] /soc/qcom,cam_smmu/msm_cam_smmu_cb4: could not get #iommu-cells for /soc/qcom,iommu@1e00000
[    5.686188] CAM-SMMU cam_populate_smmu_context_banks:1586 Invalid pointer of ctx : vfe_secure rc = -517
[    5.686190] CAM-SMMU cam_smmu_probe:1636 Error: populating context banks
[    5.686196] msm_cam_smmu: probe of soc:qcom,cam_smmu:msm_cam_smmu_cb2 failed with error -12